### PR TITLE
RDKE-782: Configure TARGET_VENDOR to rdk

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,6 +1,6 @@
 DISTRO_VERSION = "2.0"
 DISTRO_NAME="RDK (A Yocto Project based Distro)"
-
+TARGET_VENDOR = "-rdk"
 # The Artifactory for OSS IPK has to be added later
 RDK_ARTIFACTS_BASE_URL ?= ""
 CMF_GIT_ROOT ?= "git://code.rdkcentral.com/r"


### PR DESCRIPTION
Reason for the change: set the TARGET_VENDOR to '-rdk' in order to generate packages with a consistent directory structure across all layers of RDKE