### PR TITLE
RDKOSS-420: Remove duplicate configurations

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,17 +1,6 @@
 DISTRO_VERSION = "2.0"
 DISTRO_NAME="RDK (A Yocto Project based Distro)"
 TARGET_VENDOR = "-rdk"
-# The Artifactory for OSS IPK has to be added later
-RDK_ARTIFACTS_BASE_URL ?= ""
-CMF_GIT_ROOT ?= "git://code.rdkcentral.com/r"
-CMF_GIT_PROTOCOL ?= "https"
-CMF_GIT_MASTER_BRANCH ?= "master"
-
-# The Github URL is setting to RDKCentral. This may have to modify in case of any change in the settings
-RDKE_GITHUB_ROOT ?= "git://git@github.com/rdkcentral"
-RDKE_GITHUB_PROTOCOL ?= "ssh"
-RDKE_GITHUB_BRANCH ?= "nobranch=1"
-RDKE_GITHUB_SRC_URI_SUFFIX ?= "protocol=${RDKE_GITHUB_PROTOCOL};${RDKE_GITHUB_BRANCH}"
 
 #Mirror configurations
 PREMIRRORS ?= "\
@@ -41,10 +30,5 @@ DISTRO_FEATURES:append = " gobject-introspection-data"
 
 PREFERRED_PROVIDER_virtual/kernel = ""
 
-OSS_LAYER_ARCH = "${MACHINE}-oss"
-PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"
-
 # Disable layer consumption for oss layer
 USER_CLASSES:remove = "base-deps-resolver"
-
-include package_revisions_oss.inc


### PR DESCRIPTION
Reason for change: Remove redundant configurations and move OSS package arch configuration to reference layer