### PR TITLE
RDKOSS-241: Integrate rust 1.82.0 from meta-lts-mixin

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -23,4 +23,5 @@ BBLAYERS =+ "${@'${MANIFEST_PATH_PRODUCT_LAYER}' if os.path.isfile('${MANIFEST_P
 BBLAYERS =+ "${@'${MANIFEST_PATH_COMMON_OSS_REFERENCE}' if os.path.isfile('${MANIFEST_PATH_COMMON_OSS_REFERENCE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_META_PYTHON2}' if os.path.isfile('${MANIFEST_PATH_META_PYTHON2}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_OSS_EXT}' if os.path.isfile('${MANIFEST_PATH_OSS_EXT}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@'${MANIFEST_PATH_META_MIXIN}' if os.path.isfile('${MANIFEST_PATH_META_MIXIN}/conf/layer.conf') else ''}"
 


### PR DESCRIPTION
Reason for change: Include meta-lts-mixin layer to build rust version 1.82.0