### PR TITLE
RDKOSS-560: Move TARGET_VENDOR configuration

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,6 +1,5 @@
 DISTRO_VERSION = "2.0"
 DISTRO_NAME="RDK (A Yocto Project based Distro)"
-TARGET_VENDOR = "-rdk"
 
 #Mirror configurations
 PREMIRRORS ?= "\
@@ -29,6 +28,3 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED += "ldconfig"
 DISTRO_FEATURES:append = " gobject-introspection-data"
 
 PREFERRED_PROVIDER_virtual/kernel = ""
-
-# Disable layer consumption for oss layer
-USER_CLASSES:remove = "base-deps-resolver"


### PR DESCRIPTION
Reason for the change: Set the default TARGET_VENDOR value in the OSS layer