### PR TITLE
RDKOSS-500: Add ptest config

### DIFF
--- a/conf/machine/include/ptest.inc
+++ b/conf/machine/include/ptest.inc
@@ -11,7 +11,7 @@ IMAGE_INSTALL:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' gdbm-
 LICENSE_FLAGS_ACCEPTED:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only GPL-3.0-or-later', '', d)}"
 INCOMPATIBLE_LICENSE:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only LGPL-3.0-only LGPL-3.0-or-later GPL-3.0-or-later', '', d)}"
 
-# Version preferences: May go to distro config or local.conf
+# Version preferences
 PREFERRED_VERSION_libarchive = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '3.6.2', '', d)}"
 PREFERRED_VERSION_gmp = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '6.2.1', '', d)}"
 PREFERRED_VERSION_coreutils = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '9.0', '', d)}"

--- a/conf/machine/include/ptest.inc
+++ b/conf/machine/include/ptest.inc
@@ -4,7 +4,7 @@ PTEST_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1', '', d)}"
 # Image content: What to include in the image (when ptest enabled)
 EXTRA_IMAGE_FEATURES:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' ptest-pkgs', '', d)}"
 
-# For following recipes enabling ptest results in failure so removed them will work on enabling in upcoming releases
+# For the following recipes enabling ptest results in failure so removed them will work on enabling in upcoming releases
 IMAGE_INSTALL:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' gdbm-ptest pango-ptest bluez5-ptest findutils-ptest lttng-tools-ptest', '', d)}"
 
 # License policy: What licenses are acceptable in this build
@@ -21,6 +21,7 @@ CFLAGS:append:pn-glibc-tests = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest',
 PTEST_ENABLED:pn-bluez5 = "0"
 BBMASK:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' meta-rdk-oss-reference/recipes-gplv2/gettext/gettext_0.16.1.bb ', '', d)}"
 
+# Adding components for which ptest support is newly added
 PTESTS_FAST:append = " alsa-lib-ptest \
                 libatomic-ops-ptest \
                 libcheck-ptest \

--- a/conf/machine/include/ptest.inc
+++ b/conf/machine/include/ptest.inc
@@ -6,18 +6,19 @@ EXTRA_IMAGE_FEATURES:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 
 
 # For the following recipes enabling ptest results in failure so removed them will work on enabling in upcoming releases
 IMAGE_INSTALL:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' gdbm-ptest pango-ptest bluez5-ptest findutils-ptest lttng-tools-ptest', '', d)}"
+PTEST_ENABLED:pn-bluez5 = "0"
 
 # License policy: What licenses are acceptable in this build
 LICENSE_FLAGS_ACCEPTED:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only GPL-3.0-or-later', '', d)}"
 INCOMPATIBLE_LICENSE:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only LGPL-3.0-only LGPL-3.0-or-later GPL-3.0-or-later', '', d)}"
 
-# Version preferences
+# To supress compilation error in glibc-tests when ptest is enabled
+CFLAGS:append:pn-glibc-tests = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' -Wno-error=format-overflow', '', d)}"
+
+# Version preferences, lower versions doesn't have ptest support
 PREFERRED_VERSION_gmp = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '6.2.1', '', d)}"
 PREFERRED_VERSION_coreutils = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '9.0', '', d)}"
 PREFERRED_VERSION_m4 = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1.4.19', '', d)}"
-CFLAGS:append:pn-glibc-tests = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' -Wno-error=format-overflow', '', d)}"
-
-PTEST_ENABLED:pn-bluez5 = "0"
 BBMASK:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' meta-rdk-oss-reference/recipes-gplv2/gettext/gettext_0.16.1.bb ', '', d)}"
 
 # Adding components for which ptest support is newly added

--- a/conf/machine/include/ptest.inc
+++ b/conf/machine/include/ptest.inc
@@ -1,0 +1,42 @@
+# Global: Enable ptest framework for all packages
+PTEST_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1', '', d)}"
+
+# Image content: What to include in the image (when ptest enabled)
+EXTRA_IMAGE_FEATURES:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' ptest-pkgs', '', d)}"
+
+# For following recipes enabling ptest results in failure so removed them will work on enabling in upcoming releases
+IMAGE_INSTALL:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' gdbm-ptest pango-ptest bluez5-ptest findutils-ptest lttng-tools-ptest', '', d)}"
+
+# License policy: What licenses are acceptable in this build
+LICENSE_FLAGS_ACCEPTED:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only GPL-3.0-or-later', '', d)}"
+INCOMPATIBLE_LICENSE:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only LGPL-3.0-only LGPL-3.0-or-later GPL-3.0-or-later', '', d)}"
+
+# Version preferences: May go to distro config or local.conf
+PREFERRED_VERSION_libarchive = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '3.6.2', '', d)}"
+PREFERRED_VERSION_gmp = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '6.2.1', '', d)}"
+PREFERRED_VERSION_coreutils = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '9.0', '', d)}"
+PREFERRED_VERSION_m4 = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1.4.19', '', d)}"
+PREFERRED_VERSION_sed = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '4.1.2', '', d)}"
+CFLAGS:append:pn-glibc-tests = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' -Wno-error=format-overflow', '', d)}"
+PTEST_ENABLED:pn-bluez5 = "0"
+BBMASK:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' meta-rdk-oss-reference/recipes-gplv2/gettext/gettext_0.16.1.bb ', '', d)}"
+
+PTESTS_FAST:append = " alsa-lib-ptest \
+                libatomic-ops-ptest \
+                libcheck-ptest \
+                xz-ptest \
+                libcap-ptest \
+                kbd-ptest \
+                file-ptest \
+                zstd-ptest \
+                attr-ptest \
+                grep-ptest \
+                curl-ptest \
+                make-ptest \
+                libpcap-ptest \
+                apr-util-ptest \
+                libxslt-ptest \
+                lz4-ptest \
+                gmp-ptest \
+                opkg-utils-ptest \
+              "

--- a/conf/machine/include/ptest.inc
+++ b/conf/machine/include/ptest.inc
@@ -12,12 +12,11 @@ LICENSE_FLAGS_ACCEPTED:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest'
 INCOMPATIBLE_LICENSE:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' GPL-3.0-only LGPL-3.0-only LGPL-3.0-or-later GPL-3.0-or-later', '', d)}"
 
 # Version preferences
-PREFERRED_VERSION_libarchive = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '3.6.2', '', d)}"
 PREFERRED_VERSION_gmp = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '6.2.1', '', d)}"
 PREFERRED_VERSION_coreutils = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '9.0', '', d)}"
 PREFERRED_VERSION_m4 = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1.4.19', '', d)}"
-PREFERRED_VERSION_sed = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '4.1.2', '', d)}"
 CFLAGS:append:pn-glibc-tests = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' -Wno-error=format-overflow', '', d)}"
+
 PTEST_ENABLED:pn-bluez5 = "0"
 BBMASK:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', ' meta-rdk-oss-reference/recipes-gplv2/gettext/gettext_0.16.1.bb ', '', d)}"
 

--- a/conf/machine/rdk-arm64.conf
+++ b/conf/machine/rdk-arm64.conf
@@ -36,3 +36,6 @@ VIRTUAL-RUNTIME_initscripts ?= "systemd-compat-units"
 #OSS includes
 include conf/machine/include/oss.inc
 include conf/include/oss-config.inc
+
+#ptest include
+include ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'conf/machine/include/ptest.inc', '', d)}

--- a/conf/machine/rdk-arm7a.conf
+++ b/conf/machine/rdk-arm7a.conf
@@ -27,3 +27,6 @@ VIRTUAL-RUNTIME_initscripts ?= "systemd-compat-units"
 #OSS includes
 include conf/machine/include/oss.inc
 include conf/include/oss-config.inc
+
+#ptest include
+include ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'conf/machine/include/ptest.inc', '', d)}

--- a/conf/machine/rdk-arm7ve.conf
+++ b/conf/machine/rdk-arm7ve.conf
@@ -29,3 +29,6 @@ VIRTUAL-RUNTIME_initscripts ?= "systemd-compat-units"
 #OSS includes
 include conf/machine/include/oss.inc
 include conf/include/oss-config.inc
+
+#ptest include
+include ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'conf/machine/include/ptest.inc', '', d)}

--- a/conf/machine/rdk-cortexa15.conf
+++ b/conf/machine/rdk-cortexa15.conf
@@ -33,3 +33,6 @@ PREFERRED_VERSION_jsoncpp = "1:1.9.5"
 PREFERRED_VERSION_dnsmasq = "2.83"
 PREFERRED_VERSION_gettext-native = "0.21"
 PREFERRED_VERSION_bluez5 = "5.66"
+
+#ptest include
+include ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'conf/machine/include/ptest.inc', '', d)}


### PR DESCRIPTION
Reason for change: Add ptest config on demand if ptest distro is enabled
Test procedure: Changes should effect only if distro is enabled
Risk: Low