### PR TITLE
RDKOSS-1063: OSS Release 4.14.0

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -27,5 +27,5 @@ BBLAYERS =+ "${@'${MANIFEST_PATH_META_CLANG}' if os.path.isfile('${MANIFEST_PATH
 BBLAYERS =+ "${@'${MANIFEST_PATH_META_MIXIN}' if os.path.isfile('${MANIFEST_PATH_META_MIXIN}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_STACK_LAYERING_SUPPORT') if d.getVar('MANIFEST_PATH_STACK_LAYERING_SUPPORT') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_STACK_LAYERING_SUPPORT') + '/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_DOCKER_GENERATOR') if d.getVar('MANIFEST_PATH_DOCKER_GENERATOR') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_DOCKER_GENERATOR') + '/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_META_RDK_BLUETOOTH}' if os.path.isfile('${MANIFEST_PATH_META_RDK_BLUETOOTH}/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_META_BINDER}' if os.path.isfile('${MANIFEST_PATH_META_BINDER}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_META_RDK_BLUETOOTH') if d.getVar('MANIFEST_PATH_META_RDK_BLUETOOTH') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_META_RDK_BLUETOOTH') + '/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_META_BINDER') if d.getVar('MANIFEST_PATH_META_BINDER') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_META_BINDER') + '/conf/layer.conf') else ''}"

--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -27,3 +27,5 @@ BBLAYERS =+ "${@'${MANIFEST_PATH_META_CLANG}' if os.path.isfile('${MANIFEST_PATH
 BBLAYERS =+ "${@'${MANIFEST_PATH_META_MIXIN}' if os.path.isfile('${MANIFEST_PATH_META_MIXIN}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_STACK_LAYERING_SUPPORT') if d.getVar('MANIFEST_PATH_STACK_LAYERING_SUPPORT') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_STACK_LAYERING_SUPPORT') + '/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_DOCKER_GENERATOR') if d.getVar('MANIFEST_PATH_DOCKER_GENERATOR') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_DOCKER_GENERATOR') + '/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@'${MANIFEST_PATH_META_RDK_BLUETOOTH}' if os.path.isfile('${MANIFEST_PATH_META_RDK_BLUETOOTH}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@'${MANIFEST_PATH_META_BINDER}' if os.path.isfile('${MANIFEST_PATH_META_BINDER}/conf/layer.conf') else ''}"


### PR DESCRIPTION
Reason for change : we have added two new repositories in oss layer which needs to be referenced in bblayers.conf file.The below changes were done.
Add conditional inclusion of meta-rdk-bluetooth layer in bblayers.conf.sample.
Add conditional inclusion of meta-binder layer in bblayers.conf.sample.
meta-rdk-bluetooth layer 
meta-binder layer 
Test procedure: Build should succeed with references to the below in the log
meta-rdk-bluetooth - /home/ubuntu/builds/rdk-e/rdk-yocto-gha-jobs/rdke/common/oss/meta-rdk-bluetooth/bluez5/bluez5_5.48.bb
Risk: Low